### PR TITLE
Remove references to separate entries from the names of the subdivisi…

### DIFF
--- a/src/build/groovy/generateSubdivisions.groovy
+++ b/src/build/groovy/generateSubdivisions.groovy
@@ -40,7 +40,7 @@ JClass parseHtml(CountryCode cc, URL uri) {
                 throw new RuntimeException("For ${uri}, expected (Country=${cc}) but found (Country=${newCC})")
             }
             def subDivisionCode = trim(row.child(1).text())
-            def subDivisionName = trim(row.child(2).text())
+            def subDivisionName = trim(row.child(2).text().replaceFirst(/\(.+separate entry[^\)]+\)/,""))
             parsedData[subDivisionCode] = subDivisionName;
         }
     } catch (FileNotFoundException ignored) {


### PR DESCRIPTION
…ons.

Some subdivisions have references in the description, that is not part of the name, these should be removed.  For example in http://www.unece.org/fileadmin/DAM/cefact/locode/Subdivision/usSub.htm there are extra parts for American Samoa, Guam and a few others.
